### PR TITLE
Issue #4 Make pre-built module available for download from the Release page

### DIFF
--- a/.github/workflows/build_and_release_when_tagged.yml
+++ b/.github/workflows/build_and_release_when_tagged.yml
@@ -1,0 +1,105 @@
+name: Build and release JDK8-Compat when tagged
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      matrix:
+        java: [ '8' ]
+
+    env:
+      GIT_ORIGIN:           https://github.com/openam-jp
+      GIT_BRANCH:           master
+      ARTIFACT_DIR:         /tmp/target
+      REPO_NAMES: |
+                            jdk8-compat
+
+    steps:
+
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+        architecture: x64
+    
+    - name: Clone source codes
+      run: |
+    
+        for REPO in ${REPO_NAMES}; do
+          git clone \
+            ${GIT_ORIGIN}/${REPO} \
+            -b ${GIT_BRANCH}
+        done
+
+    - name: Build in order
+      run: |
+    
+        mkdir -p ${ARTIFACT_DIR}
+        LOG_FILE=${ARTIFACT_DIR}/.build.log
+    
+        BASE_DIR=$(pwd)
+        for REPO in ${REPO_NAMES}; do
+          cd ${BASE_DIR}/${REPO}
+          mvn clean install \
+              -DskipTests=true \
+              -Dmaven.test.failure.ignore=true \
+            | tee -a ${LOG_FILE}
+        done
+
+    - name: Get the version
+      id: extract_version
+      run: |
+
+        echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        ## usage: ${{ steps.extract_version.outputs.VERSION }}
+
+    - name: Collect release artifact
+      id: collect_artifact
+      run: |
+
+        ## Extract artifact(s)
+        find . -name *.jar -not -name *-sources.* \
+          | xargs -I% mv % ${ARTIFACT_DIR}/.
+
+    - name: Create the Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: "${{ steps.extract_version.outputs.VERSION }}"
+        release_name: "${{ steps.extract_version.outputs.VERSION }}"
+        draft: false
+        prerelease: false
+
+    - name: Build GitHub-API URL
+      id: api_url
+      run: |
+
+        echo ::set-output name=RELEASE::https://api.github.com/repos/${{ github.repository }}/releases/${{ steps.create_release.outputs.id }}
+        echo ::set-output name=UPLOAD::https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.create_release.outputs.id }}/assets
+        ## usage: ${{ steps.api_url.outputs.RELEASE }}
+        ## usage: ${{ steps.api_url.outputs.UPLOAD }}
+
+    - name: Upload assets
+      id: upload-release-asset 
+      run: |
+
+        cd ${ARTIFACT_DIR}
+        for ARTIFACT in $(ls .); do
+          echo "uploading: ${ARTIFACT}"
+          curl -sS \
+            --request PUT \
+            --url "${{ steps.api_url.outputs.UPLOAD }}?name=${ARTIFACT}" \
+            --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header "content-type: application/octet-stream" \
+            --data-binary @${ARTIFACT}
+        done


### PR DESCRIPTION
## Description

Add a CI script `.github/workflows/build_and_release_when_tagged.yml` for GitHub-Actions.
If detects that a new tag has been added, it adds the Release and adds the assets into it.

The structure of this script is the same as the one to build OpenAM.
The only difference is that when the `jdk8-compat` project is built, it generates an archived jar of source code, which is excluded from the collection.
